### PR TITLE
Make buffer grow as needed to accommodate additional data

### DIFF
--- a/lib/Message.js
+++ b/lib/Message.js
@@ -1,7 +1,8 @@
 var spareBytes = 512;
 
-var MessageBuilder = exports.MessageBuilder = function MessageBuilder() {
-  this.buffer = new Buffer(10000);
+var MessageBuilder = exports.MessageBuilder = function MessageBuilder(maxBytes) {
+  this.maxBytes = maxBytes || 20000000;
+  this.buffer = new Buffer(Math.min(maxBytes, 10000));
   this.cursor = 0;
 };
 MessageBuilder.prototype.raw = function raw() {
@@ -85,9 +86,13 @@ MessageBuilder.prototype.putVarString = function putVarString(str) {
   return this.putVarInt(str.length).putString(str);
 };
 MessageBuilder.prototype.ensureSize = function ensureSize(additionalBytes) {
-  if (this.cursor + additionalBytes > this.buffer.length) {
+  var requiredBytes = this.cursor + additionalBytes;
+
+  if (requiredBytes > this.maxBytes) {
+    throw new Error('Message size is limited to ' + this.maxBytes + ' bytes');
+  } else if (requiredBytes > this.buffer.length) {
     var oldBuffer = this.buffer;
-    this.buffer = new Buffer(this.cursor + additionalBytes + spareBytes);
+    this.buffer = new Buffer(Math.min(this.maxBytes, requiredBytes + spareBytes));
     oldBuffer.copy(this.buffer);
   }
   return this;

--- a/lib/Message.js
+++ b/lib/Message.js
@@ -1,3 +1,5 @@
+var spareBytes = 512;
+
 var MessageBuilder = exports.MessageBuilder = function MessageBuilder() {
   this.buffer = new Buffer(10000);
   this.cursor = 0;
@@ -14,11 +16,13 @@ MessageBuilder.prototype.pad = function pad(num) {
 };
 MessageBuilder.prototype.put = function put(data) {
   if (typeof data == 'number' && data <= 255) {
+    this.ensureSize(1);
     this.buffer[this.cursor] = data;
     this.cursor += 1;
     return this;
   }
   
+  this.ensureSize(data.length);
   data.copy(this.buffer, this.cursor);
   this.cursor += data.length;
   return this;
@@ -80,6 +84,14 @@ MessageBuilder.prototype.putVarInt = function putVarInt(num) {
 MessageBuilder.prototype.putVarString = function putVarString(str) {
   return this.putVarInt(str.length).putString(str);
 };
+MessageBuilder.prototype.ensureSize = function ensureSize(additionalBytes) {
+  if (this.cursor + additionalBytes > this.buffer.length) {
+    var oldBuffer = this.buffer;
+    this.buffer = new Buffer(this.cursor + additionalBytes + spareBytes);
+    oldBuffer.copy(this.buffer);
+  }
+  return this;
+}
 
 
 var MessageParser = exports.MessageParser = function MessageParser(raw) {

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -54,4 +54,9 @@ describe('Builder', function() {
     assert.equal(str.length, 40002)
     assert(/^(01){10000}(0203){5000}ff$/.test(str))
   })
+  it('should limit the maximum size', function() {
+    var b = new Builder(15000)
+    for (var i=0; i<15000; i++) b.put(1)
+    assert.throws(function(){ b.put(1) }, /Message size is limited/)
+  })
 });


### PR DESCRIPTION
Currently, the buffer is limited to 10,000 bytes, and attempting to push any additional data results in an error.

This PR makes the buffer grow as needed to allow for additional data. A failing test case was added separately in https://github.com/cryptocoinjs/crypto-binary/commit/67d9a9fcad5fd638a7f72bd9d8d0d2eabb6b1e5d.
